### PR TITLE
Add pipewire-utils for pw-play audio support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,7 +15,7 @@ ENV CONTAINER_SUBSYS="flatpak-spawn --host podman"
 # Pinentry/gnome-keyring needed for GPG signing,etc
 # flatpak-xdg-open allows for opening the browser outside of the toolbox
 # guestfs-tools provides virt-builder for building custom disk images
-ENV PKGS="make gcc bison binutils jq flatpak flatpak-spawn glab httpie NetworkManager nodejs-npm tmux flatpak-xdg-open gnome-keyring glab pinentry ShellCheck skopeo tox yamllint yq guestfs-tools"
+ENV PKGS="make gcc bison binutils jq flatpak flatpak-spawn glab httpie NetworkManager nodejs-npm tmux flatpak-xdg-open gnome-keyring glab pinentry ShellCheck skopeo tox yamllint yq guestfs-tools pipewire-utils"
 ENV LANGUAGE_PKGS="python3 python3-pip tinygo"
 ENV DOCUMENT_PKGS="pandoc texlive"
 


### PR DESCRIPTION
## Summary

- Adds `pipewire-utils` to the base PKGS list in the Containerfile
- Provides `pw-play` CLI for playing audio notifications from inside the toolbox
- PipeWire socket is bind-mounted from the host at `/run/user/.../pipewire-0`, so `pw-play` routes audio through the host's PipeWire to speakers/headphones
- Required by [peon-ping](https://github.com/clcollins/peon-ping) (Claude Code sound notifications)

## Test plan

- [ ] `make test` passes (image builds with pipewire-utils installed)
- [ ] `pw-play --version` works inside the new toolbox image
- [ ] Audio plays from toolbox to host speakers via PipeWire socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)