### PR TITLE
Remove nodejs-npm, add bats and python3-ansible-lint

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,7 +15,7 @@ ENV CONTAINER_SUBSYS="flatpak-spawn --host podman"
 # Pinentry/gnome-keyring needed for GPG signing,etc
 # flatpak-xdg-open allows for opening the browser outside of the toolbox
 # guestfs-tools provides virt-builder for building custom disk images
-ENV PKGS="make gcc bison binutils jq flatpak flatpak-spawn glab httpie NetworkManager nodejs-npm tmux flatpak-xdg-open gnome-keyring glab pinentry ShellCheck skopeo tox yamllint yq guestfs-tools pipewire-utils"
+ENV PKGS="make gcc bison binutils jq flatpak flatpak-spawn glab httpie NetworkManager tmux flatpak-xdg-open gnome-keyring glab pinentry ShellCheck skopeo tox yamllint yq guestfs-tools pipewire-utils bats python3-ansible-lint"
 ENV LANGUAGE_PKGS="python3 python3-pip tinygo"
 ENV DOCUMENT_PKGS="pandoc texlive"
 


### PR DESCRIPTION
## Summary
- Remove `nodejs-npm` from the base `PKGS` list (unused/redundant)
- Add `bats` and `python3-ansible-lint` for linting support

This addresses a further round of Copilot review feedback on the Containerfile package list, following up on the promtool/kustomize/kubeseal/kubectl additions merged in #5.

## Test plan
- [ ] `make validate`
- [ ] `make test` (full image build)
- [ ] Confirm `bats` and `python3-ansible-lint` are installed and usable in the built image
- [ ] Confirm `nodejs-npm` removal doesn't break any other tooling that assumed it was present

🤖 Generated with [Claude Code](https://claude.com/claude-code)