### PR TITLE
Add Visual Studio Code from Microsoft RPM repository

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -62,6 +62,18 @@ RUN dnf config-manager addrepo --from-repofile=${GH_CLI} \
   && dnf clean all \
   && rm --recursive --force /var/cache/yum/
 
+# Install Visual Studio Code
+# Repository: https://code.visualstudio.com/docs/setup/linux#_rhel-fedora-and-centos-based-distributions
+ENV VSCODE_REPO="https://packages.microsoft.com/yumrepos/vscode"
+ENV VSCODE_REPO_NAME="vscode"
+ENV VSCODE_KEY="https://packages.microsoft.com/keys/microsoft.asc"
+
+RUN rpm --import ${VSCODE_KEY} \
+  && dnf config-manager addrepo --set=baseurl=${VSCODE_REPO} --id=${VSCODE_REPO_NAME} --set=enabled=0 \
+  && dnf install --assumeyes --from-repo=${VSCODE_REPO_NAME} code \
+  && dnf clean all \
+  && rm --recursive --force /var/cache/yum/
+
 # Install Claude Code
 # Download, verify checksum, and install; then update to latest
 ARG CLAUDE_VERSION="2.1.39"


### PR DESCRIPTION
## Summary
- Adds the Microsoft VS Code RPM repository following the same disabled-repo pattern used for Google Cloud CLI, HashiCorp Vault, and GitHub CLI
- Installs the `code` package (stable VS Code) directly in the toolbox image
- Eliminates the need for the Flatpak + Dev Containers remote-attach workflow (`toolbox-vscode`), since VS Code runs natively inside the toolbox with full access to all dev tools, languages, and environment

## Test plan
- [x] Installed VS Code RPM in running devtools toolbox
- [x] Launched VS Code GUI from inside the toolbox — renders correctly on Wayland
- [x] Migrated settings, snippets, and extensions from Flatpak config — all load correctly
- [ ] Rebuild full image with `make test` to verify clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)